### PR TITLE
Add missing UriBuilder

### DIFF
--- a/Classes/OpenidModuleSetup.php
+++ b/Classes/OpenidModuleSetup.php
@@ -14,6 +14,7 @@ namespace FoT3\Openid;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\GeneralUtility;


### PR DESCRIPTION
Add missing namespace. Avoid error: `Class 'FoT3\Openid\UriBuilder' not found`